### PR TITLE
Add specific tag and resources section for the pause container

### DIFF
--- a/content/posts/2023/2023-02-03-quick-and-dirty-way-to-prepull-contianer-images-on-kubernetes/index.md
+++ b/content/posts/2023/2023-02-03-quick-and-dirty-way-to-prepull-contianer-images-on-kubernetes/index.md
@@ -49,7 +49,14 @@ spec:
       # but doesn't take up resource on the cluster
       containers:
         - name: pause
-          image: gcr.io/google_containers/pause
+          image: gcr.io/google_containers/pause:3.2
+          resources:
+            limits:
+              cpu: 1m
+              memory: 8Mi
+            requests:
+              cpu: 1m
+              memory: 8Mi
 ```
 
 Once you've applied this `DaemonSet` you can watch the pre-puller Pods and once they are all in a `Running` phase you know the images have been pulled.


### PR DESCRIPTION
Great post, thank you!

This change should let kubelet not have to get the latest image for pause container and reduce ambiguity of how much resource pause container really eats. Validated in minikube.