### PR TITLE
Add Matplotlib to EffVer usage

### DIFF
--- a/content/posts/2024/2024-01-15-effver/index.md
+++ b/content/posts/2024/2024-01-15-effver/index.md
@@ -69,6 +69,7 @@ As your project matures you will likely find yourself incrementing the _Macro_ v
 Here are some notable projects that use EffVer:
 
 - [kr8s](https://github.com/kr8s-org/kr8s)
+- [Matplotlib](https://github.com/matplotlib/matplotlib)
 
 _Want to add your project to this list, [make a PR here](https://github.com/jacobtomlinson/website/blob/master/content/posts/2024/2024-01-15-effver/index.md)._
 


### PR DESCRIPTION
As off https://github.com/matplotlib/matplotlib/pull/27702 Matplotlib follows EffVer