### PR TITLE
Add napari link to the list of projects that have adopted EffVer

### DIFF
--- a/content/posts/2024/2024-01-15-effver/index.md
+++ b/content/posts/2024/2024-01-15-effver/index.md
@@ -92,8 +92,8 @@ Here are some notable projects that use EffVer (in alphabetical order):
 - [Kr8s](https://github.com/kr8s-org/kr8s)
 - [LightGBM](https://lightgbm.readthedocs.io/en/latest/Installation-Guide.html#versioning)
 - [Matplotlib](https://github.com/matplotlib/matplotlib)
-- [Zarr](https://zarr.readthedocs.io/en/latest/developers/contributing.html#versioning)
 - [napari](https://github.com/napari/napari)
+- [Zarr](https://zarr.readthedocs.io/en/latest/developers/contributing.html#versioning)
 
 _Want to add your project to this list, [make a PR here](https://github.com/jacobtomlinson/website/blob/master/content/posts/2024/2024-01-15-effver/index.md)._
 


### PR DESCRIPTION
napari has (finally) officially adopted EffVer https://github.com/napari/napari/pull/8243 🥳 
So, I thought I'd make a PR in case you would like to add our project to your website. Cheers
🍻 